### PR TITLE
Upgraded to .NET 5.0

### DIFF
--- a/SteamGiveawaysBot.Launcher.csproj
+++ b/SteamGiveawaysBot.Launcher.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>SteamGiveawaysBot.Launcher</RootNamespace>
   </PropertyGroup>
 

--- a/SteamGiveawaysBot.Launcher.csproj
+++ b/SteamGiveawaysBot.Launcher.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuciCLI" Version="1.3.0.1" />
+    <PackageReference Include="NuciCLI" Version="1.3.1" />
   </ItemGroup>
 
 </Project>

--- a/package.sh
+++ b/package.sh
@@ -36,17 +36,7 @@ function dotnet-pub {
     dotnet publish -c Release -r "$ARCH" -o "$OUTPUT_DIR" --self-contained=true /p:TrimUnusedDependencies=true /p:LinkDuringPublish=true
 }
 
-function prepare {
-    echo "Adding the temporary NuGet packages"
-    dotnet add package Microsoft.Packaging.Tools.Trimming --version 1.1.0-preview1-26619-01
-    #dotnet add package ILLink.Tasks --version 0.1.5-preview-1841731 --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json
-}
-
 function cleanup {
-    echo "Removing the temporary NuGet packages"
-    dotnet remove package Microsoft.Packaging.Tools.Trimming
-    #dotnet remove package ILLink.Task
-
     echo "Cleaning build output"
     rm -rf "$PUBLISH_DIR"
 }
@@ -55,8 +45,6 @@ function build-release {
     dotnet-pub $1
     package $1
 }
-
-prepare
 
 build-release win-x64
 build-release osx-x64


### PR DESCRIPTION
 - Upgraded the framework from `.NET Core 2.2` to `.NET 5.0`
 - Upgraded the `NuciCLI` package from `1.3.0.1` to `1.3.1`
 - Removed the use of the trimming package in the packaging script